### PR TITLE
Lex Versioning

### DIFF
--- a/lib/BotManager/client.rb
+++ b/lib/BotManager/client.rb
@@ -55,6 +55,7 @@ module BotManager
       register_slot_types_with_lex
       register_intents_with_lex
       register_bots_with_lex
+      alias_lex_bots
     end
 
     def register_alexa_bots
@@ -225,6 +226,21 @@ module BotManager
         version = @lex_manager.register_bot lex_bot
         @bot_versions[bot_name] = version
 
+      end
+
+    end
+
+    def alias_lex_bots
+
+      @bots.each do |_key, bot|
+
+        bot_name = generate_lex_full_name bot.name
+
+        bot_version = @bot_versions[bot_name]
+
+        bot_alias = "LIVE"
+
+        @lex_manager.update_bot_alias bot_name, bot_version, bot_alias
 
       end
 

--- a/lib/BotManager/client.rb
+++ b/lib/BotManager/client.rb
@@ -238,7 +238,7 @@ module BotManager
 
         bot_version = @bot_versions[bot_name]
 
-        bot_alias = "LIVE"
+        bot_alias = get_current_release_data["alias"]
 
         @lex_manager.update_bot_alias bot_name, bot_version, bot_alias
 
@@ -545,6 +545,10 @@ module BotManager
 
     def get_current_release_data
       @releases[@release]
+    end
+
+    def get_lex_bot_versions
+      @bot_versions
     end
 
   end

--- a/lib/BotManager/client.rb
+++ b/lib/BotManager/client.rb
@@ -56,6 +56,8 @@ module BotManager
       register_intents_with_lex
       register_bots_with_lex
       alias_lex_bots
+      sleep(5)
+      cleanup_lex_versions
     end
 
     def register_alexa_bots
@@ -243,6 +245,46 @@ module BotManager
         @lex_manager.update_bot_alias bot_name, bot_version, bot_alias
 
       end
+
+    end
+
+    def cleanup_lex_versions
+
+      max_versions_to_keep = 5
+
+      puts "Cleaning up lex versions"
+
+      @bots.each do |_key, bot|
+
+        bot_name = generate_lex_full_name bot.name
+
+        puts "Cleaning up versions on bot: #{bot_name}"
+
+        @lex_manager.cleanup_bot_versions bot_name, max_versions_to_keep, ["$LATEST", @bot_versions[bot_name]]
+
+      end
+
+      @intents.each do |_key, intent|
+
+        intent_name = generate_lex_full_name intent.name
+
+        puts "Cleaning up versions on intent: #{intent_name}"
+
+        @lex_manager.cleanup_intent_versions intent_name, max_versions_to_keep, ["$LATEST", @intent_versions[intent_name]]
+
+      end
+
+      @slot_types.each do |_key, slot_type|
+
+        slot_type_name = generate_lex_full_name slot_type.name
+
+        puts "Cleaning up versions on slot type: #{slot_type_name}"
+
+        @lex_manager.cleanup_slot_type_versions slot_type_name, max_versions_to_keep, ["$LATEST", @slot_type_versions[slot_type_name]]
+
+      end
+
+      puts "Finished cleaning up lex versions"
 
     end
 

--- a/lib/BotManager/client.rb
+++ b/lib/BotManager/client.rb
@@ -48,6 +48,18 @@ module BotManager
       @bots[parsed_bot.name] = parsed_bot
     end
 
+    def register_lex_bots
+      register_slot_types_with_lex
+      register_intents_with_lex
+      register_bots_with_lex
+    end
+
+    def register_alexa_bots
+      register_bots_with_alexa
+      register_account_linking_with_alexa
+      register_interaction_model_with_alexa
+    end
+
     def register_slot_types_with_lex
 
       @slot_types.each do |_key, slot_type|

--- a/lib/BotManager/lex/client.rb
+++ b/lib/BotManager/lex/client.rb
@@ -79,6 +79,18 @@ module BotManager
           nil
         end
       end
+
+      def put_bot_alias bot_name, bot_version, alias_name, version_checksum
+        params = {bot_name: bot_name, bot_version: bot_version, name: alias_name, checksum: version_checksum}
+        begin
+          bot_alias = @lex.put_bot_alias params
+          bot_alias["name"]
+        rescue Aws::LexModelBuildingService::Errors::ServiceError => e
+          puts e
+          nil
+        end
+      end
+
       def put_slot_type slot_type_definition
         begin
           @lex.put_slot_type slot_type_definition

--- a/lib/BotManager/lex/client.rb
+++ b/lib/BotManager/lex/client.rb
@@ -50,6 +50,16 @@ module BotManager
         end
       end
 
+      def get_bot_aliases bot_name
+        params = {bot_name: bot_name}
+        begin
+          bot_aliases_response = @lex.get_bot_aliases params
+          bot_aliases_response["BotAliases"]
+        rescue Aws::LexModelBuildingService::Errors::ServiceError => e
+          []
+        end
+      end
+
       def create_slot_type_version name, checksum
         params = {name: name, checksum: checksum}
         begin

--- a/lib/BotManager/lex/client.rb
+++ b/lib/BotManager/lex/client.rb
@@ -50,6 +50,35 @@ module BotManager
         end
       end
 
+      def create_slot_type_version name, checksum
+        params = {name: name, checksum: checksum}
+        begin
+          slot_type = @lex.create_slot_type_version params
+          slot_type["version"]
+        rescue Aws::LexModelBuildingService::Errors::ServiceError => e
+          nil
+        end
+      end
+
+      def create_intent_version name, checksum
+        params = {name: name, checksum: checksum}
+        begin
+          intent = @lex.create_intent_version params
+          intent["version"]
+        rescue Aws::LexModelBuildingService::Errors::ServiceError => e
+          nil
+        end
+      end
+
+      def create_bot_version name, checksum
+        params = {name: name, checksum: checksum}
+        begin
+          bot = @lex.create_bot_version params
+          bot["version"]
+        rescue Aws::LexModelBuildingService::Errors::ServiceError => e
+          nil
+        end
+      end
       def put_slot_type slot_type_definition
         begin
           @lex.put_slot_type slot_type_definition

--- a/lib/BotManager/lex/client.rb
+++ b/lib/BotManager/lex/client.rb
@@ -40,6 +40,16 @@ module BotManager
         end
       end
 
+      def get_bot_alias_checksum bot_name, alias_name
+        params = {bot_name: bot_name, name: alias_name}
+        begin
+          bot_alias = @lex.get_bot_alias params
+          bot_alias["checksum"]
+        rescue Aws::LexModelBuildingService::Errors::NotFoundException => e
+          nil
+        end
+      end
+
       def put_slot_type slot_type_definition
         begin
           @lex.put_slot_type slot_type_definition

--- a/lib/BotManager/lex/client.rb
+++ b/lib/BotManager/lex/client.rb
@@ -166,6 +166,36 @@ module BotManager
         end
       end
 
+      def delete_slot_type_version name, version
+        params = {name: name, version: version}
+        begin
+          @lex.delete_slot_type_version params
+        rescue Aws::LexModelBuildingService::Errors::NotFoundException => e
+          puts e
+          nil
+        end
+      end
+
+      def delete_intent_version name, version
+        params = {name: name, version: version}
+        begin
+          @lex.delete_intent_version params
+        rescue Aws::LexModelBuildingService::Errors::NotFoundException => e
+          puts e
+          nil
+        end
+      end
+
+      def delete_bot_version name, version
+        params = {name: name, version: version}
+        begin
+          @lex.delete_bot_version params
+        rescue Aws::LexModelBuildingService::Errors::NotFoundException => e
+          puts e
+          nil
+        end
+      end
+
       def delete_bot_alias bot_name, alias_name
         params = {bot_name: bot_name, alias: alias_name}
         begin

--- a/lib/BotManager/lex/client.rb
+++ b/lib/BotManager/lex/client.rb
@@ -64,6 +64,17 @@ module BotManager
         end
       end
 
+      def get_bot_build_status bot_name, version_or_alias
+        params = {name: bot_name, version_or_alias: version_or_alias}
+        begin
+          bot = @lex.get_bot params
+          bot["status"]
+        rescue Aws::LexModelBuildingService::Errors::NotFoundException => e
+          puts e
+          nil
+        end
+      end
+
     end
 
   end

--- a/lib/BotManager/lex/client.rb
+++ b/lib/BotManager/lex/client.rb
@@ -136,6 +136,15 @@ module BotManager
         end
       end
 
+      def delete_bot_alias bot_name, alias_name
+        params = {bot_name: bot_name, alias: alias_name}
+        begin
+          @lex.delete_bot_alias params
+        rescue Aws::LexModelBuildingService::Errors::NotFoundException => e
+          puts e
+        end
+      end
+
     end
 
   end

--- a/lib/BotManager/lex/client.rb
+++ b/lib/BotManager/lex/client.rb
@@ -60,6 +60,36 @@ module BotManager
         end
       end
 
+      def get_slot_type_versions name
+        params = {name: name, max_results: 50}
+        begin
+          slot_types_response = @lex.get_slot_type_versions params
+          slot_types_response["slot_types"]
+        rescue Aws::LexModelBuildingService::Errors::ServiceError => e
+          []
+        end
+      end
+
+      def get_intent_versions name
+        params = {name: name, max_results: 50}
+        begin
+          intents_response = @lex.get_intent_versions params
+          intents_response["intents"]
+        rescue Aws::LexModelBuildingService::Errors::ServiceError => e
+          []
+        end
+      end
+
+      def get_bot_versions name
+        params = {name: name, max_results: 50}
+        begin
+          bots_response = @lex.get_bot_versions params
+          bots_response["bots"]
+        rescue Aws::LexModelBuildingService::Errors::ServiceError => e
+          []
+        end
+      end
+
       def create_slot_type_version name, checksum
         params = {name: name, checksum: checksum}
         begin

--- a/lib/BotManager/lex/manager.rb
+++ b/lib/BotManager/lex/manager.rb
@@ -92,6 +92,90 @@ module BotManager
 
       end
 
+      def cleanup_slot_type_versions slot_type_name, max_to_keep, versions_to_ignore
+
+        versions = @lex_client.get_slot_type_versions slot_type_name
+
+        versions = versions.keep_if { |v| !versions_to_ignore.include? v[:version] }
+
+        if versions.length > max_to_keep
+
+          versions.sort! {|a,b| a[:last_updated_date] <=> b[:last_updated_date]}
+
+          versions_to_delete = versions[0...-max_to_keep]
+
+          versions_to_delete.each do |version|
+
+            version_id = version[:version]
+
+            puts "Removing version #{version_id} from slot type #{slot_type_name}"
+
+            @lex_client.delete_slot_type_version slot_type_name, version_id
+
+            sleep(3)
+
+          end
+
+        end
+
+      end
+
+      def cleanup_intent_versions intent_name, max_to_keep, versions_to_ignore
+
+        versions = @lex_client.get_intent_versions intent_name
+
+        versions = versions.keep_if { |v| !versions_to_ignore.include? v[:version] }
+
+        if versions.length > max_to_keep
+
+          versions.sort! {|a,b| a[:last_updated_date] <=> b[:last_updated_date]}
+
+          versions_to_delete = versions[0...-max_to_keep]
+
+          versions_to_delete.each do |version|
+
+            version_id = version[:version]
+
+            puts "Removing version #{version_id} from intent #{intent_name}"
+
+            @lex_client.delete_intent_version intent_name, version_id
+
+            sleep(3)
+
+          end
+
+        end
+
+      end
+
+      def cleanup_bot_versions bot_name, max_to_keep, versions_to_ignore
+
+        versions = @lex_client.get_bot_versions bot_name
+
+        versions = versions.keep_if { |v| !versions_to_ignore.include? v[:version] }
+
+        if versions.length > max_to_keep
+
+          versions.sort! {|a,b| a[:last_updated_date] <=> b[:last_updated_date]}
+
+          versions_to_delete = versions[0...-max_to_keep]
+
+          versions_to_delete.each do |version|
+
+            version_id = version[:version]
+
+            puts "Removing version #{version_id} from bot #{bot_name}"
+
+            @lex_client.delete_bot_version bot_name, version_id
+
+            sleep(3)
+
+          end
+
+        end
+
+      end
+
     end
 
   end

--- a/lib/BotManager/lex/manager.rb
+++ b/lib/BotManager/lex/manager.rb
@@ -82,6 +82,14 @@ module BotManager
 
       end
 
+      def update_bot_alias bot_name, version, bot_alias
+
+        puts "Updating bot alias #{bot_alias} for bot: #{bot_name}"
+
+        alias_checksum = @lex_client.get_bot_alias_checksum bot_name, bot_alias
+
+        @lex_client.put_bot_alias bot_name, version, bot_alias, alias_checksum
+
       end
 
     end


### PR DESCRIPTION
Add versioning support to lex for the following:

- Slot Types
- Intents
- Bots

Creates new versions on changes to Slot Types, Intents and Bots.

Handles updating the defined release alias for the lex bot on each bot rollout.

Cleans up the outdated versions keeping 5 previous versions for each slot type, intent and bot.