### PR TITLE
AWS QnA bot

### DIFF
--- a/lib/BotManager/alexa/manager.rb
+++ b/lib/BotManager/alexa/manager.rb
@@ -11,7 +11,7 @@ module BotManager
 
       def initialize client_id, client_secret, refresh_token, vendor_id
         @client = Api::Client.new client_id, client_secret, refresh_token
-        @lambda = Aws::Lambda::Client.new
+        @lambda = ::Aws::Lambda::Client.new
         @vendor_id = vendor_id
         @skills = {}
         pre_load_skills

--- a/lib/BotManager/aws.rb
+++ b/lib/BotManager/aws.rb
@@ -1,0 +1,7 @@
+require 'BotManager/aws/qna_bot'
+
+module BotManager
+  module Aws
+
+  end
+end

--- a/lib/BotManager/aws/qna_bot.rb
+++ b/lib/BotManager/aws/qna_bot.rb
@@ -1,0 +1,57 @@
+require 'BotManager/lex'
+
+module BotManager
+
+  module Aws
+
+    class QnaBot
+
+      attr_reader :name, :version
+
+      def initialize name, version
+        @name = name
+        @version = version
+        @lex_client = Lex::Client.new
+        @bot = retrieve_bot
+        @intent = retrieve_intent
+        @slot_type = retrieve_slot_type
+      end
+
+      def get_slot_enumerations
+        @slot_type[:enumeration_values]
+      end
+
+      def get_fulfillment_activity
+
+        @intent[:fulfillment_activity]
+
+      end
+
+      private
+
+      def retrieve_bot
+        @lex_client.get_bot @name, @version
+      end
+
+      def retrieve_slot_type
+
+        slot_type = @intent[:slots][0][:slot_type]
+        slot_type_version = @intent[:slots][0][:slot_type_version]
+
+        @lex_client.get_slot_type slot_type, slot_type_version
+
+      end
+
+      def retrieve_intent
+
+        intent_name = @bot[:intents][0][:intent_name]
+        intent_version = @bot[:intents][0][:intent_version]
+
+        @lex_client.get_intent intent_name, intent_version
+      end
+
+    end
+
+  end
+
+end

--- a/lib/BotManager/lex/client.rb
+++ b/lib/BotManager/lex/client.rb
@@ -7,7 +7,7 @@ module BotManager
     class Client
 
       def initialize
-        @lex = Aws::LexModelBuildingService::Client.new
+        @lex = ::Aws::LexModelBuildingService::Client.new
       end
 
       def get_slot_type_checksum name, version
@@ -15,7 +15,7 @@ module BotManager
         begin
           slot_type = @lex.get_slot_type params
           slot_type["checksum"]
-        rescue Aws::LexModelBuildingService::Errors::NotFoundException => e
+        rescue ::Aws::LexModelBuildingService::Errors::NotFoundException => e
           nil
         end
       end
@@ -25,7 +25,7 @@ module BotManager
         begin
           intent = @lex.get_intent params
           intent["checksum"]
-        rescue Aws::LexModelBuildingService::Errors::NotFoundException => e
+        rescue ::Aws::LexModelBuildingService::Errors::NotFoundException => e
           nil
         end
       end
@@ -35,7 +35,34 @@ module BotManager
         begin
           bot = @lex.get_bot params
           bot["checksum"]
-        rescue Aws::LexModelBuildingService::Errors::NotFoundException => e
+        rescue ::Aws::LexModelBuildingService::Errors::NotFoundException => e
+          nil
+        end
+      end
+
+      def get_slot_type name, version
+        params = {name: name, version: version}
+        begin
+          @lex.get_slot_type params
+        rescue ::Aws::LexModelBuildingService::Errors::NotFoundException => e
+          nil
+        end
+      end
+
+      def get_intent name, version
+        params = {name: name, version: version}
+        begin
+          @lex.get_intent params
+        rescue ::Aws::LexModelBuildingService::Errors::NotFoundException => e
+          nil
+        end
+      end
+
+      def get_bot name, version_or_alias
+        params = {name: name, version_or_alias: version_or_alias}
+        begin
+          @lex.get_bot params
+        rescue ::Aws::LexModelBuildingService::Errors::NotFoundException => e
           nil
         end
       end
@@ -45,7 +72,7 @@ module BotManager
         begin
           bot_alias = @lex.get_bot_alias params
           bot_alias["checksum"]
-        rescue Aws::LexModelBuildingService::Errors::NotFoundException => e
+        rescue ::Aws::LexModelBuildingService::Errors::NotFoundException => e
           nil
         end
       end
@@ -55,7 +82,7 @@ module BotManager
         begin
           bot_aliases_response = @lex.get_bot_aliases params
           bot_aliases_response["BotAliases"]
-        rescue Aws::LexModelBuildingService::Errors::ServiceError => e
+        rescue ::Aws::LexModelBuildingService::Errors::ServiceError => e
           []
         end
       end
@@ -65,7 +92,7 @@ module BotManager
         begin
           slot_types_response = @lex.get_slot_type_versions params
           slot_types_response["slot_types"]
-        rescue Aws::LexModelBuildingService::Errors::ServiceError => e
+        rescue ::Aws::LexModelBuildingService::Errors::ServiceError => e
           []
         end
       end
@@ -75,7 +102,7 @@ module BotManager
         begin
           intents_response = @lex.get_intent_versions params
           intents_response["intents"]
-        rescue Aws::LexModelBuildingService::Errors::ServiceError => e
+        rescue ::Aws::LexModelBuildingService::Errors::ServiceError => e
           []
         end
       end
@@ -85,7 +112,7 @@ module BotManager
         begin
           bots_response = @lex.get_bot_versions params
           bots_response["bots"]
-        rescue Aws::LexModelBuildingService::Errors::ServiceError => e
+        rescue ::Aws::LexModelBuildingService::Errors::ServiceError => e
           []
         end
       end
@@ -95,7 +122,7 @@ module BotManager
         begin
           slot_type = @lex.create_slot_type_version params
           slot_type["version"]
-        rescue Aws::LexModelBuildingService::Errors::ServiceError => e
+        rescue ::Aws::LexModelBuildingService::Errors::ServiceError => e
           nil
         end
       end
@@ -105,7 +132,7 @@ module BotManager
         begin
           intent = @lex.create_intent_version params
           intent["version"]
-        rescue Aws::LexModelBuildingService::Errors::ServiceError => e
+        rescue ::Aws::LexModelBuildingService::Errors::ServiceError => e
           nil
         end
       end
@@ -115,7 +142,7 @@ module BotManager
         begin
           bot = @lex.create_bot_version params
           bot["version"]
-        rescue Aws::LexModelBuildingService::Errors::ServiceError => e
+        rescue ::Aws::LexModelBuildingService::Errors::ServiceError => e
           nil
         end
       end
@@ -125,7 +152,7 @@ module BotManager
         begin
           bot_alias = @lex.put_bot_alias params
           bot_alias["name"]
-        rescue Aws::LexModelBuildingService::Errors::ServiceError => e
+        rescue ::Aws::LexModelBuildingService::Errors::ServiceError => e
           puts e
           nil
         end
@@ -134,7 +161,7 @@ module BotManager
       def put_slot_type slot_type_definition
         begin
           @lex.put_slot_type slot_type_definition
-        rescue Aws::LexModelBuildingService::Errors::ServiceError => e
+        rescue ::Aws::LexModelBuildingService::Errors::ServiceError => e
           puts e
         end
       end
@@ -142,7 +169,7 @@ module BotManager
       def put_intent intent_definition
         begin
           @lex.put_intent intent_definition
-        rescue Aws::LexModelBuildingService::Errors::ServiceError => e
+        rescue ::Aws::LexModelBuildingService::Errors::ServiceError => e
           puts e
         end
       end
@@ -150,7 +177,7 @@ module BotManager
       def put_bot bot_definition
         begin
           @lex.put_bot bot_definition
-        rescue Aws::LexModelBuildingService::Errors::ServiceError => e
+        rescue ::Aws::LexModelBuildingService::Errors::ServiceError => e
           puts e
         end
       end
@@ -160,7 +187,7 @@ module BotManager
         begin
           bot = @lex.get_bot params
           bot["status"]
-        rescue Aws::LexModelBuildingService::Errors::NotFoundException => e
+        rescue ::Aws::LexModelBuildingService::Errors::NotFoundException => e
           puts e
           nil
         end
@@ -170,7 +197,10 @@ module BotManager
         params = {name: name, version: version}
         begin
           @lex.delete_slot_type_version params
-        rescue Aws::LexModelBuildingService::Errors::NotFoundException => e
+        rescue ::Aws::LexModelBuildingService::Errors::ResourceInUseException => e
+          puts "Version in use unable to delete"
+          nil
+        rescue ::Aws::LexModelBuildingService::Errors::NotFoundException => e
           puts e
           nil
         end
@@ -180,7 +210,10 @@ module BotManager
         params = {name: name, version: version}
         begin
           @lex.delete_intent_version params
-        rescue Aws::LexModelBuildingService::Errors::NotFoundException => e
+        rescue ::Aws::LexModelBuildingService::Errors::ResourceInUseException => e
+          puts "Version in use unable to delete"
+          nil
+        rescue ::Aws::LexModelBuildingService::Errors::NotFoundException => e
           puts e
           nil
         end
@@ -190,7 +223,10 @@ module BotManager
         params = {name: name, version: version}
         begin
           @lex.delete_bot_version params
-        rescue Aws::LexModelBuildingService::Errors::NotFoundException => e
+        rescue ::Aws::LexModelBuildingService::Errors::ResourceInUseException => e
+          puts "Version in use unable to delete"
+          nil
+        rescue ::Aws::LexModelBuildingService::Errors::NotFoundException => e
           puts e
           nil
         end
@@ -200,7 +236,7 @@ module BotManager
         params = {bot_name: bot_name, alias: alias_name}
         begin
           @lex.delete_bot_alias params
-        rescue Aws::LexModelBuildingService::Errors::NotFoundException => e
+        rescue ::Aws::LexModelBuildingService::Errors::NotFoundException => e
           puts e
         end
       end

--- a/lib/BotManager/lex/manager.rb
+++ b/lib/BotManager/lex/manager.rb
@@ -112,7 +112,7 @@ module BotManager
 
             @lex_client.delete_slot_type_version slot_type_name, version_id
 
-            sleep(3)
+            sleep(5)
 
           end
 
@@ -140,7 +140,7 @@ module BotManager
 
             @lex_client.delete_intent_version intent_name, version_id
 
-            sleep(3)
+            sleep(5)
 
           end
 
@@ -168,7 +168,7 @@ module BotManager
 
             @lex_client.delete_bot_version bot_name, version_id
 
-            sleep(3)
+            sleep(5)
 
           end
 

--- a/lib/BotManager/parsers/bot_parser.rb
+++ b/lib/BotManager/parsers/bot_parser.rb
@@ -38,6 +38,10 @@ module BotManager
         @bot[:intents]
       end
 
+      def aws_qna_intents
+        @bot[:aws_qna_intents]
+      end
+
     end
 
   end

--- a/lib/BotManager/parsers/template_file_parser.rb
+++ b/lib/BotManager/parsers/template_file_parser.rb
@@ -17,7 +17,8 @@ module BotManager
         file = file.gsub('${ACCOUNT_LINKING_CLIENT_SECRET}', BotManager::TemplateConfig.account_linking_client_secret)
         file = file.gsub('${ACCOUNT_LINKING_ACCESS_TOKEN_URL}', BotManager::TemplateConfig.account_linking_access_token_url)
         file = file.gsub('${QNA_ID}', BotManager::TemplateConfig.qna_id)
-        file = file.gsub('${QNA_BOT_NAME', BotManager::TemplateConfig.qna_bot_name)
+        file = file.gsub('${QNA_BOT_NAME}', BotManager::TemplateConfig.qna_bot_name)
+        file = file.gsub('${QNA_BOT_VERSION}', BotManager::TemplateConfig.qna_bot_version)
 
         file
 

--- a/lib/BotManager/parsers/template_file_parser.rb
+++ b/lib/BotManager/parsers/template_file_parser.rb
@@ -17,6 +17,7 @@ module BotManager
         file = file.gsub('${ACCOUNT_LINKING_CLIENT_SECRET}', BotManager::TemplateConfig.account_linking_client_secret)
         file = file.gsub('${ACCOUNT_LINKING_ACCESS_TOKEN_URL}', BotManager::TemplateConfig.account_linking_access_token_url)
         file = file.gsub('${QNA_ID}', BotManager::TemplateConfig.qna_id)
+        file = file.gsub('${QNA_BOT_NAME', BotManager::TemplateConfig.qna_bot_name)
 
         file
 

--- a/lib/BotManager/template_config.rb
+++ b/lib/BotManager/template_config.rb
@@ -10,7 +10,7 @@ module BotManager
     @account_linking_access_token_url = nil
 
     class << self
-      attr_accessor :account_id, :deploy_env, :account_linking_authorization_url, :account_linking_client_id, :account_linking_client_secret, :account_linking_access_token_url, :qna_id
+      attr_accessor :account_id, :deploy_env, :account_linking_authorization_url, :account_linking_client_id, :account_linking_client_secret, :account_linking_access_token_url, :qna_id, :qna_bot_name
     end
 
   end

--- a/lib/BotManager/template_config.rb
+++ b/lib/BotManager/template_config.rb
@@ -10,7 +10,7 @@ module BotManager
     @account_linking_access_token_url = nil
 
     class << self
-      attr_accessor :account_id, :deploy_env, :account_linking_authorization_url, :account_linking_client_id, :account_linking_client_secret, :account_linking_access_token_url, :qna_id, :qna_bot_name
+      attr_accessor :account_id, :deploy_env, :account_linking_authorization_url, :account_linking_client_id, :account_linking_client_secret, :account_linking_access_token_url, :qna_id, :qna_bot_name, :qna_bot_version
     end
 
   end


### PR DESCRIPTION
Adds support for the AWS QnA bot template.

This pulls down the slot type enumerations from the lex console by getting the bot, the bots first intent and the intents first slot type.

This allows an easy way of integrating with the predefined AWS Lex QnA bot and adding it as a supported intent in new bots.